### PR TITLE
fix: Elasticsearch master replicaCount を 1 に修正

### DIFF
--- a/manifests/growi/values-elasticsearch.yaml
+++ b/manifests/growi/values-elasticsearch.yaml
@@ -7,7 +7,7 @@ image:
   pullPolicy: IfNotPresent
 master:
   masterOnly: true
-  replicaCount: 0
+  replicaCount: 1
   resources:
     requests:
       cpu: 250m


### PR DESCRIPTION
## Summary

- Bitnami Elasticsearch Chart の値バリデーションエラーを修正
- `master.replicaCount: 0` は Chart 側でハードエラーになるため `1` に変更
- Growi 本体（`replicas: 0`）・MongoDB（`replicaCount: 0`）・バックアップ CronJob（`suspend: true`）は引き続き停止状態を維持

## 原因

```
VALUES VALIDATION: elasticsearch: master.replicas
Elasticsearch needs at least one master-eligible node to form a cluster.
```

`replicaCount: 0` を設定すると `helm template` 自体が失敗し、ArgoCD がマニフェストを生成できなくなる。

## Test plan

- [ ] ArgoCD の k8s-growi Application が ComparisonError から回復すること
- [ ] Growi の Pod が起動していないこと（replicas: 0 のまま）

🤖 Generated with [Claude Code](https://claude.com/claude-code)