### PR TITLE
feat: migrate infrastructure to Proxmox VE with Terraform and Ansible

### DIFF
--- a/manifests/growi/kustomization.yaml
+++ b/manifests/growi/kustomization.yaml
@@ -13,14 +13,14 @@ resources:
 helmCharts:
 - name: mongodb
   repo: oci://registry-1.docker.io/bitnamicharts
-  version: 16.5.26
+  version: 18.6.1
   releaseName: mongodb
   namespace: growi
   valuesFile: values-mongodb.yaml
   valuesMerge: override
 - name: elasticsearch
   repo: oci://registry-1.docker.io/bitnamicharts
-  version: 22.0.9
+  version: 22.1.6
   releaseName: elasticsearch
   namespace: growi
   valuesFile: values-elasticsearch.yaml

--- a/manifests/growi/values-elasticsearch.yaml
+++ b/manifests/growi/values-elasticsearch.yaml
@@ -2,8 +2,8 @@
 plugins: "analysis-kuromoji,analysis-icu"
 image:
   registry: docker.io
-  repository: bitnami/elasticsearch
-  tag: latest
+  repository: bitnamilegacy/elasticsearch
+  tag: 9.1.2
   pullPolicy: IfNotPresent
 master:
   masterOnly: true

--- a/manifests/growi/values-mongodb.yaml
+++ b/manifests/growi/values-mongodb.yaml
@@ -1,8 +1,8 @@
 ---
 image:
   registry: docker.io
-  repository: bitnami/mongodb
-  tag: 7.0.8-debian-12-r2
+  repository: bitnamilegacy/mongodb
+  tag: 8.0.13
   pullPolicy: IfNotPresent
 auth:
   enabled: true

--- a/manifests/nextcloud/kustomization.yaml
+++ b/manifests/nextcloud/kustomization.yaml
@@ -7,16 +7,16 @@ helmCharts:
   repo: https://nextcloud.github.io/helm/
   releaseName: nextcloud
   namespace: nextcloud
-  version: 8.9.1
+  version: 9.0.1
   valuesFile: values.yaml
   valuesMerge: override
 images:
 - name: nextcloud
   newTag: 33.0.0-fpm
-- name: docker.io/bitnami/mariadb
-  newTag: latest
-- name: docker.io/bitnami/redis
-  newTag: latest
+- name: docker.io/bitnamilegacy/mariadb
+  newTag: 12.0.2
+- name: docker.io/bitnamilegacy/redis
+  newTag: 8.2.1
 patches:
 - patch: |-
     - op: add

--- a/manifests/rss-generator/kustomization.yaml
+++ b/manifests/rss-generator/kustomization.yaml
@@ -10,14 +10,14 @@ resources:
 helmCharts:
 - name: mariadb
   repo: oci://registry-1.docker.io/bitnamicharts
-  version: 20.5.9
+  version: 25.0.1
   releaseName: mariadb
   namespace: rss-generator
   valuesFile: values-mariadb.yaml
   valuesMerge: override
 - name: selenium-grid
   repo: https://www.selenium.dev/docker-selenium
-  version: 0.44.2
+  version: 0.52.0
   releaseName: selenium
   namespace: rss-generator
   valuesFile: values-selenium.yaml

--- a/manifests/rss-generator/values-mariadb.yaml
+++ b/manifests/rss-generator/values-mariadb.yaml
@@ -1,8 +1,8 @@
 ---
 image:
   registry: docker.io
-  repository: bitnami/mariadb
-  tag: latest
+  repository: bitnamilegacy/mariadb
+  tag: 12.0.2
   pullPolicy: IfNotPresent
 auth:
   database: rss

--- a/manifests/rss-notifier/kustomization.yaml
+++ b/manifests/rss-notifier/kustomization.yaml
@@ -10,7 +10,7 @@ resources:
 helmCharts:
 - name: mariadb
   repo: oci://registry-1.docker.io/bitnamicharts
-  version: 21.0.3
+  version: 25.0.1
   releaseName: mariadb
   namespace: rss-notifier
   valuesFile: values-mariadb.yaml

--- a/manifests/rss-notifier/values-mariadb.yaml
+++ b/manifests/rss-notifier/values-mariadb.yaml
@@ -1,8 +1,8 @@
 ---
 image:
   registry: docker.io
-  repository: bitnami/mariadb
-  tag: latest
+  repository: bitnamilegacy/mariadb
+  tag: 12.0.2
   pullPolicy: IfNotPresent
 auth:
   database: rss_notifier


### PR DESCRIPTION
## Summary

- Proxmox VE を基盤とした新しいインフラ構成（Terraform + Ansible）を追加
- Terraform（bpg/proxmox）で control-plane × 1、worker × 1 の VM をプロビジョニング
- Ansible で kubeadm + Calico CNI による Kubernetes クラスタのセットアップを自動化
- ArgoCD のデプロイを Ansible ロールとして追加、各種 playbook を整備
- 各種マニフェストのイメージタグ・リポジトリを最新化（mongodb, elasticsearch, mariadb, nextcloud）

## Changes

### Infrastructure (Terraform)
- `terraform/` ディレクトリ追加：Proxmox VE VM プロビジョニング
- Cloudflare R2 バックエンドで Terraform state 管理
- control-plane（2コア/8GB/30GB）、worker（10コア/32GB/150GB）のVM定義

### Automation (Ansible)
- `ansible/` ディレクトリ追加：k8s インストール自動化
- ロール：`common`, `containerd`, `k8s_control_plane`, `k8s_node`, `k8s_worker`, `k8s_namespaces`, `argocd`, `storage`
- Playbook：`site.yml`, `control_plane.yml`, `workers.yml`, `argocd.yml`, `fetch_kubeconfig.yml`, `reset.yml`
- HDD マウント用 `storage` ロール追加

### Documentation
- `docs/terraform.md`, `docs/ansible.md` 追加
- 設計ドキュメント（`docs/design/`）追加：overview, terraform, ansible, cleanup
- アーキテクチャ・ネットワーク図（PlantUML + PNG）追加
- インシデント記録：`docs/incidents/20260307-calico-network.md`（Calico CrossSubnet IPIP mode 設定）

### Manifests
- Bitnami イメージの最新タグへ更新（mongodb, elasticsearch, mariadb）
- nextcloud イメージおよび Helm chart 更新
- ArgoCD kustomization パッチ修正

## Test plan

- [ ] `terraform plan` でエラーなく VM プロビジョニング計画が生成されること
- [ ] `ansible-playbook --check` で dry-run が通ること
- [ ] `kubectl kustomize --enable-helm` で各マニフェストが正常レンダリングされること

🤖 Generated with [Claude Code](https://claude.com/claude-code)