### PR TITLE
fix: update DNS servers config and fix ingress-nginx admission webhook network policy

### DIFF
--- a/manifests/ingress-nginx/network-policy.yaml
+++ b/manifests/ingress-nginx/network-policy.yaml
@@ -64,3 +64,10 @@ spec:
       port: 80
     - protocol: TCP
       port: 443
+  # Allow kube-apiserver to reach admission webhook (port 8443)
+  - from:
+    - ipBlock:
+        cidr: 192.168.1.200/32
+    ports:
+    - protocol: TCP
+      port: 8443

--- a/terraform/control_plane.tf
+++ b/terraform/control_plane.tf
@@ -39,7 +39,7 @@ resource "proxmox_virtual_environment_vm" "control_plane" {
     }
 
     dns {
-      servers = [var.dns_server]
+      servers = var.dns_servers
     }
   }
 

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -9,7 +9,7 @@ vm_user        = "k8s"
 ssh_public_key = "ssh-ed25519 AAAA... your-public-key"
 
 gateway_ip = "192.168.1.1"
-dns_server = "192.168.1.1"
+dns_servers = ["8.8.8.8", "192.168.1.1"]
 
 control_plane_ip        = "192.168.1.200/24"
 control_plane_cpu_cores = 2

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -49,10 +49,10 @@ variable "gateway_ip" {
   description = "Default gateway IP"
 }
 
-variable "dns_server" {
-  type        = string
-  default     = "8.8.8.8"
-  description = "DNS server IP"
+variable "dns_servers" {
+  type        = list(string)
+  default     = ["8.8.8.8", "192.168.1.1"]
+  description = "DNS server IPs (in priority order)"
 }
 
 # Control plane

--- a/terraform/workers.tf
+++ b/terraform/workers.tf
@@ -55,7 +55,7 @@ resource "proxmox_virtual_environment_vm" "workers" {
     }
 
     dns {
-      servers = [var.dns_server]
+      servers = var.dns_servers
     }
   }
 
@@ -69,4 +69,11 @@ resource "proxmox_virtual_environment_vm" "workers" {
   }
 
   serial_device {}
+
+  lifecycle {
+    ignore_changes = [
+      # Passthrough HDD size is reported by Proxmox and differs from Terraform default
+      disk,
+    ]
+  }
 }


### PR DESCRIPTION
## Summary

- Terraform の DNS 設定を複数サーバー対応に変更（`8.8.8.8` 優先、`192.168.1.1` フォールバック）
- ingress-nginx の NetworkPolicy に kube-apiserver からの admission webhook（port 8443）アクセスを許可するルールを追加

## Changes

### Terraform
- `variables.tf`: `dns_server` (string) → `dns_servers` (list(string)) に変更
- `control_plane.tf` / `workers.tf`: `var.dns_servers` を参照するよう更新
- `terraform.tfvars` / `terraform.tfvars.example`: `dns_servers = ["8.8.8.8", "192.168.1.1"]` に更新
- `workers.tf`: パススルー HDD のディスクサイズ差分を抑制する `lifecycle.ignore_changes` を追加

### Manifests
- `manifests/ingress-nginx/network-policy.yaml`: kube-apiserver（192.168.1.200）から port 8443 への ingress ルールを追加（admission webhook タイムアウト修正）

## Background

ingress-nginx の admission webhook（port 8443）が NetworkPolicy によってブロックされており、`kubectl apply` 時に `context deadline exceeded` エラーが発生していた。

## Test plan

- [ ] `terraform plan` でディスクサイズの差分が出ないこと
- [ ] `kubectl apply -k ingress` がエラーなく完了すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)