### PR TITLE
fix: fix nextcloud image tag override and exclude growi from ArgoCD

### DIFF
--- a/manifests/nextcloud/kustomization.yaml
+++ b/manifests/nextcloud/kustomization.yaml
@@ -11,7 +11,7 @@ helmCharts:
   valuesFile: values.yaml
   valuesMerge: override
 images:
-- name: nextcloud
+- name: docker.io/library/nextcloud
   newTag: 32.0.6-fpm
 - name: docker.io/bitnamilegacy/mariadb
   newTag: 12.0.2


### PR DESCRIPTION
## Summary

- nextcloud の kustomize image 上書きが効いておらず Helm chart デフォルト（v33）が使われ CrashLoopBackOff が発生していたため修正
- ArgoCD ApplicationSet から growi を除外

## Changes

### manifests/nextcloud/kustomization.yaml
- `name: nextcloud` → `name: docker.io/library/nextcloud` に修正
- kustomize が Helm chart の image 参照（`docker.io/library/nextcloud`）と正しくマッチするようになり、`32.0.6-fpm` が適用される

### manifests/argocd/application-set.yaml
- `manifests/growi` を `exclude: true` で除外

## Background

- v31 → v33 への直接アップグレードは非対応（1メジャーバージョンずつ更新が必要）
- まず v32 で起動させ、その後 v33 へ段階的にアップグレードする

## Test plan

- [ ] `kustomize build --enable-helm manifests/nextcloud/` で `nextcloud:32.0.6-fpm` が出力されること
- [ ] ArgoCD sync 後に nextcloud Pod が正常起動すること
- [ ] ArgoCD に `k8s-growi` Application が生成されないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)