### PR TITLE
feat: add metrics-server for HPA support

### DIFF
--- a/manifests/metrics-server/kustomization.yaml
+++ b/manifests/metrics-server/kustomization.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- https://github.com/kubernetes-sigs/metrics-server/releases/download/v0.8.1/components.yaml
+patches:
+- patch: |-
+    - op: add
+      path: /spec/template/spec/containers/0/args/-
+      value: --kubelet-insecure-tls
+  target:
+    kind: Deployment
+    name: metrics-server


### PR DESCRIPTION
## Summary

- metrics-server v0.8.1 を追加
- HPA（HorizontalPodAutoscaler）の動作に必要なリソースメトリクスを提供

## Changes

### manifests/metrics-server/kustomization.yaml
- 公式リリースの `components.yaml` を remote resource として参照
- kubeadm 環境向けに `--kubelet-insecure-tls` を patch で追加

## Background

nextcloud の HPA が metrics-server なしでは機能しないため追加。
また ArgoCD の `autoscaling/v1` → `v2` 変換エラーの根本対応として metrics-server を導入し HPA を正常稼働させる。

## Test plan

- [ ] `kubectl get pods -n kube-system | grep metrics-server` で Pod が Running になること
- [ ] `kubectl top nodes` でメトリクスが取得できること

🤖 Generated with [Claude Code](https://claude.com/claude-code)